### PR TITLE
GIT-0000: Remove apiKey from default object

### DIFF
--- a/MMM-nyc-transit.js
+++ b/MMM-nyc-transit.js
@@ -7,7 +7,6 @@
 Module.register('MMM-nyc-transit', { /*eslint-disable-line*/
     // Default module config.
     defaults: {
-        apikey: 'YOUR_KEY_HERE',
         mtaType: 'train',
         stations: [318, 611],
         updateInterval: 300000, // every 5 min


### PR DESCRIPTION
### Description: ✍️
* Removes unused `apiKey` key:value pair from default config
