### PR TITLE
Add w train color support

### DIFF
--- a/MMM-nyc-transit.css
+++ b/MMM-nyc-transit.css
@@ -88,7 +88,8 @@
 
 .mta__train--line-n,
 .mta__train--line-q,
-.mta__train--line-r {
+.mta__train--line-r,
+.mta__train--line-w {
   background: #fccc0a;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MMM-nyc-transit",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MMM-nyc-transit",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "New York City realtime transit module for magic mirror",
   "main": "MMM-nyc-transit.js",
   "scripts": {


### PR DESCRIPTION
### Description: ✍️
* Add support for W train 

### Issue(s): 🎟️
* #18 

### Visual: 🔍
<!-- Drag - n - Drop your image here -->
#### Before:
<img width="751" alt="Screen Shot 2019-11-12 at 1 00 08 PM" src="https://user-images.githubusercontent.com/710847/68698342-baee7880-054e-11ea-9cd8-7bc76c1acb00.png">

#### After:
<img width="851" alt="Screen Shot 2019-11-12 at 1 19 01 PM" src="https://user-images.githubusercontent.com/710847/68698519-086ae580-054f-11ea-8240-26467ac127f4.png">

### Reference(s): 📖
* [MTA train line colors](http://web.mta.info/developers/resources/line_colors.htm)
