### PR TITLE
Support multiple instances of MMM-nyc-transit with different configurations

### DIFF
--- a/MMM-nyc-transit.js
+++ b/MMM-nyc-transit.js
@@ -323,12 +323,12 @@ Module.register('MMM-nyc-transit', { /*eslint-disable-line*/
     }, loadTime)
   },
 
-  arrayEquals: function (a, b) {
-    if (a.length !== b.length) {
+  stationArrayEquals: function (stationsLeft, stationsRight) {
+    if (stationsLeft.length !== stationsRight.length) {
       return false
     } else {
-      for (var i = 0; i < a.length; i++) {
-        if (a[i] !== b[i]) {
+      for (var i = 0; i < stationsLeft.length; i++) {
+        if (stationsLeft[i] !== stationsRight[i]) {
           return false
         }
       }
@@ -340,7 +340,7 @@ Module.register('MMM-nyc-transit', { /*eslint-disable-line*/
   socketNotificationReceived: function (notification, payload) {
     var myStations = this.config.stations.map((obj) => obj.stationId)
 
-    if (notification === 'TRAIN_TABLE' && this.arrayEquals(payload['stations'], myStations)) {
+    if (notification === 'TRAIN_TABLE' && this.stationArrayEquals(payload['stations'], myStations)) {
       // eslint-disable-next-line no-console
       console.log('socketNotificationReceived: "TRAIN_TABLE": ', this.result)
 

--- a/MMM-nyc-transit.js
+++ b/MMM-nyc-transit.js
@@ -323,12 +323,28 @@ Module.register('MMM-nyc-transit', { /*eslint-disable-line*/
     }, loadTime)
   },
 
+  arrayEquals: function (a, b) {
+    if (a.length !== b.length) {
+      return false
+    } else {
+      for (var i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+          return false
+        }
+      }
+
+      return true
+    }
+  },
+
   socketNotificationReceived: function (notification, payload) {
-    if (notification === 'TRAIN_TABLE') {
+    var myStations = this.config.stations.map((obj) => obj.stationId)
+
+    if (notification === 'TRAIN_TABLE' && this.arrayEquals(payload['stations'], myStations)) {
       // eslint-disable-next-line no-console
       console.log('socketNotificationReceived: "TRAIN_TABLE": ', this.result)
 
-      this.result = payload
+      this.result = payload['data']
       this.updateDom(self.config.fadeSpeed)
     } else if (notification === 'DOM_OBJECTS_CREATED') {
       // eslint-disable-next-line no-console

--- a/node_helper.js
+++ b/node_helper.js
@@ -145,30 +145,42 @@ module.exports = NodeHelper.create({
               })
 
               if (isList) {
-                self.sendSocketNotification('TRAIN_TABLE', [
-                  { downTown: downTown.filter((train) => train.time > 0),},
-                  { upTown: upTown.filter((train) => train.time > 0),},
-                ])
+                self.sendSocketNotification('TRAIN_TABLE', {
+                  stations: stations,
+                  data: [
+                    { downTown: downTown.filter((train) => train.time > 0),},
+                    { upTown: upTown.filter((train) => train.time > 0),},
+                  ]
+                })
               } else {
-                self.sendSocketNotification('TRAIN_TABLE', [
-                  { downTown: downTown.filter((train) => train.time > 0).slice(0, 3),},
-                  { upTown: upTown.filter((train) => train.time > 0).slice(0, 3),},
-                ])
+                self.sendSocketNotification('TRAIN_TABLE', {
+                  stations: stations,
+                  data: [
+                    { downTown: downTown.filter((train) => train.time > 0).slice(0, 3),},
+                    { upTown: upTown.filter((train) => train.time > 0).slice(0, 3),},
+                  ]
+                })
               }
             })
           })
         })
 
         if (isList) {
-          self.sendSocketNotification('TRAIN_TABLE', [
-            { downTown: downTown.filter((train) => train.time > 0),},
-            { upTown: upTown.filter((train) => train.time > 0) },
-          ])
+          self.sendSocketNotification('TRAIN_TABLE', {
+            stations: stations,
+            data: [
+              { downTown: downTown.filter((train) => train.time > 0),},
+              { upTown: upTown.filter((train) => train.time > 0) },
+            ]
+          })
         } else {
-          self.sendSocketNotification('TRAIN_TABLE', [
-            { downTown: downTown.filter((train) => train.time > 0).slice(0, 3),},
-            { upTown: upTown.filter((train) => train.time > 0).slice(0, 3),},
-          ])
+          self.sendSocketNotification('TRAIN_TABLE', {
+            stations: stations,
+            data: [
+              { downTown: downTown.filter((train) => train.time > 0).slice(0, 3),},
+              { upTown: upTown.filter((train) => train.time > 0).slice(0, 3),}
+            ]
+          })
         }
       })
       .catch((err) => {


### PR DESCRIPTION
This patch allows multiple instances of MMM-nyc-transit to coexist within the same MagicMirror config such that each instance will only update if it receives a socket notification that includes data about the stations the instance is tracking. Without this change, different instances will receive each others' notifications and update incorrectly.
